### PR TITLE
Expose Coredns metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Separate coredns and node-cache metric ports.
+
 ## [0.3.0] - 2022-04-19
 
 ### Changed

--- a/helm/k8s-dns-node-cache-app/templates/configmap.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 force_tcp
         }
-        prometheus :{{ .Values.ports.prometheus }}
+        prometheus :{{ .Values.ports.prometheus.coredns }}
         health {{ .Values.cluster.kubernetes.DNS.IP }}:{{ .Values.ports.liveness }}
     }
     in-addr.arpa:{{ .Values.upstreamService.servicePort }} {
@@ -31,7 +31,7 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 force_tcp
         }
-        prometheus :{{ .Values.ports.prometheus }}
+        prometheus :{{ .Values.ports.prometheus.coredns }}
     }
     ip6.arpa:{{ .Values.upstreamService.servicePort }} {
         errors
@@ -42,7 +42,7 @@ data:
         forward . __PILLAR__CLUSTER__DNS__ {
                 force_tcp
         }
-        prometheus :{{ .Values.ports.prometheus }}
+        prometheus :{{ .Values.ports.prometheus.coredns }}
     }
     .:{{ .Values.upstreamService.servicePort }} {
         errors
@@ -51,5 +51,5 @@ data:
         loop
         bind {{ .Values.cluster.kubernetes.DNS.IP }}
         forward . __PILLAR__UPSTREAM__SERVERS__
-        prometheus :{{ .Values.ports.prometheus }}
+        prometheus :{{ .Values.ports.prometheus.coredns }}
     }

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         - -health-port
         - "{{ .Values.ports.liveness }}"
         - -metrics-listen-address
-        - "0.0.0.0:{{ .Values.ports.prometheus }}"
+        - "0.0.0.0:{{ .Values.ports.prometheus.nodecache }}"
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true
@@ -59,8 +59,11 @@ spec:
         - containerPort: {{ .Values.upstreamService.servicePort }}
           name: tcp
           protocol: TCP
-        - containerPort: {{ .Values.ports.prometheus }}
+        - containerPort: {{ .Values.ports.prometheus.nodecache }}
           name: metrics
+          protocol: TCP
+        - containerPort: {{ .Values.ports.prometheus.coredns }}
+          name: corednsmetrics
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -53,12 +53,6 @@ spec:
           allowPrivilegeEscalation: true
           privileged: true
         ports:
-        - containerPort: {{ .Values.upstreamService.servicePort }}
-          name: udp
-          protocol: UDP
-        - containerPort: {{ .Values.upstreamService.servicePort }}
-          name: tcp
-          protocol: TCP
         - containerPort: {{ .Values.ports.prometheus.nodecache }}
           name: metrics
           protocol: TCP

--- a/helm/k8s-dns-node-cache-app/templates/np.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/np.yaml
@@ -15,7 +15,9 @@ spec:
       protocol: UDP
     - port: {{ .Values.upstreamService.servicePort }}
       protocol: TCP
-    - port: {{ .Values.ports.prometheus }}
+    - port: {{ .Values.ports.prometheus.coredns }}
+      protocol: TCP
+    - port: {{ .Values.ports.prometheus.nodecache }}
       protocol: TCP
   egress:
   - {}

--- a/helm/k8s-dns-node-cache-app/templates/psp.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/psp.yaml
@@ -19,8 +19,10 @@ spec:
   hostPorts:
   - min: {{ .Values.upstreamService.servicePort }}
     max: {{ .Values.upstreamService.servicePort }}
-  - min: {{ .Values.ports.prometheus }}
-    max: {{ .Values.ports.prometheus }}
+  - min: {{ .Values.ports.prometheus.nodecache }}
+    max: {{ .Values.ports.prometheus.nodecache }}
+  - min: {{ .Values.ports.prometheus.coredns }}
+    max: {{ .Values.ports.prometheus.coredns }}
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/helm/k8s-dns-node-cache-app/templates/service.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/service.yaml
@@ -8,14 +8,14 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
-  annotations:
-    giantswarm.io/monitoring-path: /metrics
-    giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
 spec:
   selector:
     k8s-app: {{ .Values.name }}
   clusterIP: None
   ports:
   - name: metrics
-    port: {{ .Values.ports.prometheus }}
-    targetPort: {{ .Values.ports.prometheus }}
+    port: {{ .Values.ports.prometheus.nodecache }}
+    targetPort: {{ .Values.ports.prometheus.nodecache }}
+  - name: coredns
+    port: {{ .Values.ports.prometheus.coredns }}
+    targetPort: {{ .Values.ports.prometheus.coredns }}

--- a/helm/k8s-dns-node-cache-app/values.yaml
+++ b/helm/k8s-dns-node-cache-app/values.yaml
@@ -22,7 +22,9 @@ cluster:
     clusterDomain: cluster.local
 
 ports:
-  prometheus: 9253
+  prometheus:
+    nodecache: 9253
+    coredns: 9254
   liveness: 8080
 
 # Reference of the traditional coredns pods.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1056

This app exposes 2 different metrics:

- the cache app metrics
- the coredns basic metrics.

before this PR both endpoints were using the same port so only one of the two metrics were scraped.
This PR fixes this bug.