### PR TITLE
Make CoreDNS the upstream server in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use CoreDNS as upstream in order to avoid double configuration for internal domains.
+
 ## [0.4.0] - 2022-04-21
 
 ### Changed

--- a/helm/k8s-dns-node-cache-app/templates/configmap.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/configmap.yaml
@@ -50,6 +50,6 @@ data:
         reload
         loop
         bind {{ .Values.cluster.kubernetes.DNS.IP }}
-        forward . __PILLAR__UPSTREAM__SERVERS__
+        forward . __PILLAR__CLUSTER__DNS__
         prometheus :{{ .Values.ports.prometheus.coredns }}
     }


### PR DESCRIPTION
If the customer has some custom configuration in CoreDNS for internal domains, currently they have to duplicate this configuration in Node Local DNS, this change will avoid this by making NodeLocalDNS fetch from the existing CoreDNS installation which already has the custom domain names.