### PR TITLE
Revert force_tcp option

### DIFF
--- a/helm/k8s-dns-node-cache-app/templates/configmap.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/configmap.yaml
@@ -56,8 +56,6 @@ data:
         reload
         loop
         bind 0.0.0.0
-        forward . __PILLAR__CLUSTER__DNS__ {
-                force_tcp
-        }
+        forward . __PILLAR__CLUSTER__DNS__ 
         prometheus :{{ .Values.ports.prometheus.coredns }}
     }


### PR DESCRIPTION
This way, the client can select which proto to use to reach upstream
servers.

Signed-off-by: Matias Charriere <matias@giantswarm.io>
