### PR TITLE
Reduce cpu requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce CPU requests.
+
 ## [2.6.1] - 2024-02-07
 
 ### Changed

--- a/helm/k8s-dns-node-cache-app/values.yaml
+++ b/helm/k8s-dns-node-cache-app/values.yaml
@@ -40,7 +40,7 @@ upstreamService:
 
 resources:
   requests:
-    cpu: 100m
+    cpu: 50m
     memory: 100Mi
 
 configmap:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30671
Towards https://github.com/giantswarm/giantswarm/issues/30682

By default, the app uses a very small amount of the resources it requests (see https://github.com/giantswarm/cluster-aws/pull/603#issuecomment-2088447499). This PR reduces the requests and limits to be more efficient, which saves ~150m CPU in requests across a 3 node control plane.