### PR TITLE
Reduce security exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce security exceptions [#89](https://github.com/giantswarm/k8s-dns-node-cache-app/pull/89).
+  - Enable readOnly FS moving config to emptyDir volume.
+  - Remove `NET_ADMIN` and drop `ALL` capabilities.
+  - Add `NET_BIND_SERVICE` capability.
+  - Add policy exception for `require-non-root-groups/autogen-check-runasgroup`.
+  - Remove disallow-capabilities-* policy exceptions.
+
 ## [2.7.0] - 2024-06-18
 
 ### Changed

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -32,11 +32,13 @@ spec:
         resources: {{ toYaml .Values.resources | nindent 10 }}
         {{- end }}
         args:
-        - "-localip"
+        - -localip
         - "{{ .Values.cluster.kubernetes.LOCAL.IP }},{{ .Values.cluster.kubernetes.DNS.IP }}"
-        - "-conf"
-        - "/etc/Corefile"
-        - "-upstreamsvc"
+        - -basecorefile
+        - "/etc/coredns-base/Corefile.Base"
+        - -corefile
+        - "/etc/coredns/Corefile"
+        - -upstreamsvc
         - "{{ .Values.name }}-upstream"
         - -dns.port
         - "{{ .Values.upstreamService.servicePort }}"
@@ -79,6 +81,8 @@ spec:
           readOnly: false
         - name: config-volume
           mountPath: /etc/coredns
+        - name: config-base-volume
+          mountPath: /etc/coredns-base
         - name: kube-dns-config
           mountPath: /etc/kube-dns
       volumes:
@@ -90,9 +94,11 @@ spec:
         configMap:
           name: kube-dns
           optional: true
-      - name: config-volume
+      - name: config-base-volume
         configMap:
           name: {{ .Values.name }}
           items:
             - key: Corefile
               path: Corefile.base
+      - name: config-volume
+        emptyDir: {}

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -27,10 +27,8 @@ spec:
         operator: "Exists"
       securityContext:
         readOnlyRootFilesystem: true
-        runAsUser: 33
-        runAsGroup: 33
         seccompProfile:
-          type: RuntimeDefault
+          type: Unconfined
       containers:
       - name: node-cache
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -56,13 +54,11 @@ spec:
         - -setupinterface=false
         - -setupiptables=false
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
             drop:
             - ALL
-          readOnlyRootFilesystem: true
         ports:
         - containerPort: {{ .Values.ports.prometheus.nodecache }}
           name: metrics

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -48,11 +48,12 @@ spec:
         - -setupinterface=false
         - -setupiptables=false
         securityContext:
+          readOnlyRootFilesystem: true
           capabilities:
             add:
-            - NET_ADMIN
-          seccompProfile:
-            type: Unconfined
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
         ports:
         - containerPort: {{ .Values.ports.prometheus.nodecache }}
           name: metrics

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - -localip
         - "{{ .Values.cluster.kubernetes.LOCAL.IP }},{{ .Values.cluster.kubernetes.DNS.IP }}"
         - -basecorefile
-        - "/etc/coredns-base/Corefile.Base"
+        - "/etc/coredns-base/Corefile.base"
         - -corefile
         - "/etc/coredns/Corefile"
         - -upstreamsvc

--- a/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/daemonset.yaml
@@ -25,6 +25,12 @@ spec:
         operator: "Exists"
       - effect: "NoSchedule"
         operator: "Exists"
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 33
+        runAsGroup: 33
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: node-cache
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -36,7 +42,7 @@ spec:
         - "{{ .Values.cluster.kubernetes.LOCAL.IP }},{{ .Values.cluster.kubernetes.DNS.IP }}"
         - -basecorefile
         - "/etc/coredns-base/Corefile.base"
-        - -corefile
+        - -conf
         - "/etc/coredns/Corefile"
         - -upstreamsvc
         - "{{ .Values.name }}-upstream"
@@ -50,12 +56,13 @@ spec:
         - -setupinterface=false
         - -setupiptables=false
         securityContext:
-          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_BIND_SERVICE
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: {{ .Values.ports.prometheus.nodecache }}
           name: metrics

--- a/helm/k8s-dns-node-cache-app/templates/pss-exception.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/pss-exception.yaml
@@ -7,16 +7,6 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   exceptions:
-  - policyName: disallow-capabilities
-    ruleNames:
-    - adding-capabilities
-    - autogen-adding-capabilities
-  - policyName: disallow-capabilities-strict
-    ruleNames:
-    - adding-capabilities-strict
-    - autogen-adding-capabilities-strict
-    - require-drop-all
-    - autogen-require-drop-all
   - policyName: disallow-host-path
     ruleNames:
     - host-path
@@ -45,6 +35,9 @@ spec:
     ruleNames:
     - restricted-volumes
     - autogen-restricted-volumes
+  - policyName: require-non-root-groups
+    ruleNames:
+    - autogen-check-runasgroup
   match:
     any:
     - resources:


### PR DESCRIPTION
This PR:

- enables readOnly FS moving config to an emptyDir
- remove NET_ADMIN and drop ALL capabilities
- add NET_BIND_SERVICE cap
- add policy exception for `require-non-root-groups/autogen-check-runasgroup`
- remove `disallow-capabilities-*` policy exceptions

Towards https://github.com/giantswarm/giantswarm/issues/31181