### PR TITLE
Increase scrapping interval on ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Increase ServiceMonitor's scrapping interval to 1m.
+
 ## [2.8.1] - 2024-07-15
 
 ### Changed

--- a/helm/k8s-dns-node-cache-app/templates/servicemonitor-coredns.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/servicemonitor-coredns.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
     - honorLabels: true
-      interval: 10s
+      interval: 1m
       path: /metrics
       port: coredns
       relabelings:

--- a/helm/k8s-dns-node-cache-app/templates/servicemonitor-metrics.yaml
+++ b/helm/k8s-dns-node-cache-app/templates/servicemonitor-metrics.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
     - honorLabels: true
-      interval: 10s
+      interval: 1m
       path: /metrics
       port: metrics
       relabelings:


### PR DESCRIPTION
There is no need for such scrapping rate. Increasing to 1m to match coredns metrics' scrapping interval.